### PR TITLE
Fix hide and show function names and separators

### DIFF
--- a/auraxium/join.py
+++ b/auraxium/join.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, Union
 from .census import List, Term
 from .log import logger
 from .type import CensusValue
@@ -28,7 +28,7 @@ class Join():
         self._terms: List[Term] = []
         _ = [Term(k.replace('__', '.'), kwargs[k]) for k in kwargs.keys()]
 
-    def hide(self, *args: str) -> 'Join':
+    def set_hide(self, *args: Union[str, List[str]]) -> 'Join':
         """Hide the given field names from the response."""
         self.hide = list(args)
         if self.hide and self.show:
@@ -48,7 +48,7 @@ class Join():
         self._inner_joins.append(inner_join)
         return inner_join
 
-    def show(self, *args: str) -> 'Join':
+    def set_show(self, *args: Union[str, List[str]]) -> 'Join':
         """Only include the given field names in the response."""
         self.show = list(args)
         if self.hide and self.show:

--- a/auraxium/join.py
+++ b/auraxium/join.py
@@ -80,11 +80,11 @@ class Join():
             string += '^to:' + self.child_field
         # Show & hide
         if self.show:
-            string += '^show:' + ','.join(self.show)
+            string += '^show:' + "'".join(self.show)
             if self.hide:
                 logger.warning('"c:show" overwrites "c:hide"')
         elif self.hide:
-            string += '^hide:' + ','.join(self.hide)
+            string += '^hide:' + "'".join(self.hide)
         # Terms
         if self._terms:
             string += '^terms:' + '\''.join([t.to_url() for t in self._terms])

--- a/auraxium/join.py
+++ b/auraxium/join.py
@@ -12,18 +12,19 @@ class Join():
     """
 
     def __init__(self, collection: str, inject_at: str = '',
-                 is_list: bool = False,  on: str = '', is_outer: bool = True,
-                 to: str = '', **kwargs: CensusValue) -> None:
+                 is_list: bool = False, on: str = '', is_outer: bool = True,
+                 to: str = '', show: List[str] = None, hide: List[str] = None, **kwargs: CensusValue) -> None:
         """Initializer."""
+
         self.collection = collection
-        self.hide: List[str] = []
         self._inner_joins: List['Join'] = []
         self.is_list = is_list
         self.is_outer = is_outer
         self.inject_at = inject_at
         self.parent_field = on
         self.child_field = to
-        self.show: List[str] = []
+        self.show = show
+        self.hide = hide
         # Additional kwargs are passed on to the `add_term` method
         self._terms: List[Term] = []
         _ = [Term(k.replace('__', '.'), kwargs[k]) for k in kwargs.keys()]

--- a/auraxium/query.py
+++ b/auraxium/query.py
@@ -14,7 +14,7 @@ class Query():
     def __init__(self, collection: str = '', namespace: str = '',
                  service_id: str = '', case: bool = True,
                  exact_match_first: bool = False, include_null: bool = False,
-                 lang: str = '', limit: int = 1,
+                 lang: str = '', limit: int = 1, show_fields: List[str] = None, hide_fields: List[str] = None,
                  limit_per_db: Optional[int] = None, retry: bool = True,
                  start: int = 0, timing: bool = False,
                  **kwargs: CensusValue) -> None:
@@ -27,7 +27,8 @@ class Query():
         self._distinct = ''
         self.exact_match_first = exact_match_first
         self.has: List[str] = []
-        self.hide_fields: List[str] = []
+        self.show_fields = show_fields
+        self.hide_fields = hide_fields
         self.include_null = include_null
         self.lang = lang
         if limit < 1:
@@ -39,7 +40,6 @@ class Query():
         self.joins: List[Join] = []
         self.resolves: List[str] = []
         self.retry = retry
-        self.show_fields: List[str] = []
         self.start = start
         self.sort_by: List[str] = []
         self.timing = timing
@@ -101,14 +101,14 @@ class Query():
         return self
 
     def join(self, collection: str, inject_at: str = '', is_list: bool = False,
-             on: str = '', is_outer: bool = True, to: str = '',
+             on: str = '', is_outer: bool = True, to: str = '', show: List[str] = None,
              **kwargs: Tuple[str, CensusValue]) -> Join:
         """Create an inner query (or join) for this query.
 
         All arguments passed to this function are forwarded to the new
         Join's initializer. The created join is returned.
         """
-        join = Join(collection, inject_at, is_list, on, is_outer, to, **kwargs)
+        join = Join(collection, inject_at, is_list, on, is_outer, to, show, **kwargs)
         self.joins.append(join)
         return join
 

--- a/auraxium/query.py
+++ b/auraxium/query.py
@@ -90,7 +90,7 @@ class Query():
         self.has.extend(args)
         return self
 
-    def hide_fields(self, field_name: str, *args: str) -> 'Query':
+    def set_hide_fields(self, field_name: str, *args: str) -> 'Query':
         """Hide the given fields from the response.
 
         This only takes effect if `show_fields` is not specified.
@@ -156,7 +156,7 @@ class Query():
             self.resolves.extend(args)
         return self
 
-    def show_fields(self, field_name: str, *args: str) -> 'Query':
+    def set_show_fields(self, field_name: str, *args: str) -> 'Query':
         """Only include the given fields in the response.
 
         This overrides the `hide_fields` method.

--- a/auraxium/query.py
+++ b/auraxium/query.py
@@ -26,7 +26,7 @@ class Query():
         self.case = case
         self._distinct = ''
         self.exact_match_first = exact_match_first
-        self.has: List[str] = []
+        self.has_field: List[str] = []
         self.show_fields = show_fields
         self.hide_fields = hide_fields
         self.include_null = include_null
@@ -86,8 +86,8 @@ class Query():
         that are populated. Example: Only weapons using a heat
         mechanic will/should have non-NULL values for related fields.
         """
-        self.has.append(field_name)
-        self.has.extend(args)
+        self.has_field.append(field_name)
+        self.has_field.extend(args)
         return self
 
     def set_hide_fields(self, field_name: str, *args: str) -> 'Query':
@@ -206,8 +206,8 @@ def _process_query_commands(query: Query) -> List[str]:
     if query.sort_by:
         items.append('c:sort=' + ','.join(query.sort_by))
     # c:has
-    if query.has:
-        items.append('c:has=' + ','.join(query.has))
+    if query.has_field:
+        items.append('c:has=' + ','.join(query.has_field))
     # c:resolve
     if query.resolves:
         items.append('c:resolve=' + ','.join(query.resolves))


### PR DESCRIPTION
I've fixed the issue mentioned in #3 where hide and show had the same method and instance variable names. I've changed the functions to set_show and set_show_fields for join.py and query.py, since that better represents what they do.