### PR TITLE
Caught a bug where numbers were parsed as ints when generating terms

### DIFF
--- a/auraxium/census.py
+++ b/auraxium/census.py
@@ -44,14 +44,17 @@ class Term():
         modifier = '=' + MODIFIER_LIST[self.modifier.value]
         return self.field + modifier + _value_to_str(self.value)
 
+    def __eq__(self, other):
+        return self.field == other.field and self.modifier == other.modifier and self.value == other.value
 
-def generate_term(field, value: str):
-    MODIFIER_LIST: List[str] = ['', '!', '<', '[', '>', ']', '^', '*']
 
-    modifier = 0
+def generate_term(field: str, value: str):
+    """Generate a term from field and value, parsing search modifier"""
+    MODIFIER_LIST: List[str] = ['=', '!', '<', '[', '>', ']', '^', '*']
 
-    for (modifier_index, operator) in enumerate(MODIFIER_LIST[1:], start=1):  # Skip the first item, since we don't care
-        # if the modifier is '='
+    modifier = SearchModifier.EQUAL_TO
+
+    for (modifier_index, operator) in enumerate(MODIFIER_LIST):
         if operator in value:
             modifier = SearchModifier(modifier_index)
             value = value.replace(operator, '')  # remove the operator from the term

--- a/auraxium/query.py
+++ b/auraxium/query.py
@@ -47,7 +47,7 @@ class Query():
         # Additional kwargs are passed on to the `generate_term` method
         self.terms: List[Term] = []
         for field, value in kwargs.items():
-            self.terms.append(generate_term(field.replace('__', '.'), value))
+            self.terms.append(generate_term(field.replace('__', '.'), str(value)))
 
     def add_term(self, field: str, value: CensusValue,
                  modifier: SearchModifier = SearchModifier.EQUAL_TO) -> 'Query':

--- a/tests/query_test.py
+++ b/tests/query_test.py
@@ -40,6 +40,31 @@ class TestURLs(unittest.TestCase):
         test = auraxium.Query('world', name__en='Connery').url()
         self.assertEqual(test, EXPECTED)
 
+    def test_query_term_with_modifier_string(self):
+        """Test whether a modifer (>, <, [, ], *, !) is correctly handled"""
+        EXPECTED = f'{self.ENDPOINT}s:example/get/ps2:v2/character_name' \
+                   f'?name.first_lower=^lite&c:show=name.first&c:limit=10'
+        test_query = auraxium.Query('character_name', name__first_lower='^lite', limit=10, show_fields=['name.first'])
+
+        self.assertEqual(test_query.url(), EXPECTED)
+
+        correct_term = auraxium.census.Term('name.first_lower', 'lite', auraxium.census.SearchModifier.STARTS_WITH)
+
+        self.assertTrue(correct_term in test_query.terms)
+
+
+    def test_generate_term_with_extra_equals(self):
+        EXPECTED = f'{self.ENDPOINT}s:example/get/ps2:v2/character?character_id=5428018587875812257&c:show=name'
+        test = auraxium.Query('character', character_id='=5428018587875812257', show_fields=['name']).url()
+        self.assertEqual(test, EXPECTED)
+
+    def test_query_term_with_number(self):
+        """Test whether a term with a int value is correctly parsed"""
+
+        EXPECTED = f'{self.ENDPOINT}s:example/get/ps2:v2/character?character_id=5428018587875812257&c:show=name'
+        test = auraxium.Query('character', show_fields=['name'], character_id=5428018587875812257).url()
+        self.assertEqual(test, EXPECTED)
+
     def test_query_term_multi(self):
         """Test whether multiple query terms are correctly parsed."""
         # NOTE: NC Flash


### PR DESCRIPTION
**kwargs can take numbers, so checking for modifiers would fail when a term's value was passed as a number.

Fixed and added tests to catch it in future